### PR TITLE
Update cpu_top.sv

### DIFF
--- a/cpu_top.sv
+++ b/cpu_top.sv
@@ -6,18 +6,20 @@ module cpu_top(
     input aclk,
     input aresetn,
     //instruction port
-    output [31:0] addr_inst,
+    input [31:0] addr_inst,
     output [31:0] data_out_inst,
     input [31:0] data_in_inst,
-    output en_inst,
-    output we_inst,
+    input [3:0] en_inst,
+    input we_inst,
     //data port
-    output [31:0] addr_data,
+    input [31:0] addr_data,
     output [31:0] data_out_data,
     input [31:0] data_in_data,
-    output en_data,
-    output we_data
+    input en_data,
+    input [3:0] we_data
     );
+    
+    
     
     localparam c_register_file_len = 32;
     //register file
@@ -28,7 +30,13 @@ module cpu_top(
     //instruction reg -> INST_REG
     bit [31:0] INST_REG = 32'd0;
     //state tracker
-    bit [31:0] T = 'd0; 
+    bit [31:0] T = 'd0;
+//next pc 
+//    bit [31:0] next_PC; 
+
+    //PC + 4
+    wire [31:0] PC_plus_4 = PC + 4;
+    
     
     //main state machine
     always@(posedge aclk)begin
@@ -38,7 +46,8 @@ module cpu_top(
                     32'd0 : begin //INSTR fetch
                         INST_REG <= data_in_inst;
                         T <= T + 1;
-                        PC <= PC + 1;                          
+//                        PC <= next_PC;
+                        PC <= PC_plus_4;                          
                     end
                endcase
                
@@ -54,6 +63,6 @@ module cpu_top(
     
     
     //net assigments
-    assign addr_inst = PC;
+    assign addr_inst = PC[31:3]; //use word adress to read memory
     
 endmodule

--- a/cpu_top.sv
+++ b/cpu_top.sv
@@ -9,8 +9,8 @@ module cpu_top(
     input [31:0] addr_inst,
     output [31:0] data_out_inst,
     input [31:0] data_in_inst,
-    input [3:0] en_inst,
-    input we_inst,
+    input en_inst,
+    input [3:0] we_inst,
     //data port
     input [31:0] addr_data,
     output [31:0] data_out_data,

--- a/cpu_top.sv
+++ b/cpu_top.sv
@@ -1,22 +1,19 @@
-`timescale 1ns / 1ps
-
-
 module cpu_top(
     //clocking
     input aclk,
     input aresetn,
     //instruction port
-    input [31:0] addr_inst,
+    output [31:0] addr_inst,
     output [31:0] data_out_inst,
     input [31:0] data_in_inst,
-    input en_inst,
-    input [3:0] we_inst,
+    output  en_inst,
+    output [3:0] we_inst,
     //data port
-    input [31:0] addr_data,
+    output [31:0] addr_data,
     output [31:0] data_out_data,
     input [31:0] data_in_data,
-    input en_data,
-    input [3:0] we_data
+    output en_data,
+    output [3:0] we_data
     );
     
     
@@ -36,6 +33,9 @@ module cpu_top(
 
     //PC + 4
     wire [31:0] PC_plus_4 = PC + 4;
+    
+    //decoder
+    
     
     
     //main state machine


### PR DESCRIPTION
1. PC now increments +4 
Instruction memory starts at adress 4 since first 2 bits are removed (addr_inst = PC[32:2]).
2. memory is byte-addressible
Write enable now has 2 bit ports which lets us write to byte addresses 

some additional explenation for changes:
- RV32I should be byte-addresible, next quote is from chapter 2.6 of risc spec file
> RV32I is a load-store architecture, where only load and store instructions access memory and
> arithmetic instructions only operate on CPU registers. RV32I provides a 32-bit user address space
> that is byte-addressed and little-endian.

- control instructions expect for PC to be byte addressible too,  next quotes are from chapter 2.5 of risc spec file and define three type of operation where correctly aligned PC is needed 
1. jump ins 
  > The jump and link (JAL) instruction uses the J-type format, where the J-immediate encodes a
  > signed offset in multiples of 2 bytes. The offset is sign-extended and added to the pc to form the
  > jump target address. Jumps can therefore target a ±1 MiB range. JAL stores the address of the
  > instruction following the jump (pc+4) into register rd. 

2. branch ins
> All branch instructions use the B-type instruction format. The 12-bit B-immediate encodes signed
> offsets in multiples of 2, and is added to the current pc to give the target address. The conditional
> branch range is ±4 KiB.
3. jump ins
> The indirect jump instruction JALR (jump and link register) uses the I-type encoding. The target
> address is obtained by adding the 12-bit signed I-immediate to the register rs1, then setting the
> least-significant bit of the result to zero. The address of the instruction following the jump (pc+4)
> is written to register rd. Register x0 can be used as the destination if the result is not required.

theres ofcourse PC + 4 which is allready implanted, and can be considered 4. that is default for other ins

Considering all this next value of pc can be 4 options (PC_plus_4, JAL, JALR, branch). Need to recheck this before decoding commit.