### PR TITLE
Update cpu_top.sv

### DIFF
--- a/cpu_top.sv
+++ b/cpu_top.sv
@@ -16,166 +16,124 @@ module cpu_top(
     output [31:0] data_out_data,
     input [31:0] data_in_data,
     output en_data,
-    output [3:0] we_data
+    output [3:0] we_data 
     );
+    
+    
     
     //state machine enum
     typedef enum bit [2:0] {FETCH,DECODE,EXECUTE,MEMORY,WRITE_BACK} e_states;
-    typedef enum bit [31:0] {ADDI = 32'h1, SLTI = 32'h2, ANDI = 32'h4, ORI = 32'h8, XORI = 32'h10, LUI = 32'h20, AUIPC = 32'h40, SLLI = 32'h80, SRLI = 32'h100,
+    typedef enum logic [31:0] {ADDI = 32'h1, SLTI = 32'h2, ANDI = 32'h4, ORI = 32'h8, XORI = 32'h10, LUI = 32'h20, AUIPC = 32'h40, SLLI = 32'h80, SRLI = 32'h100,
                              SRAI = 32'h200, ADD = 32'h400, SUB = 32'h800,_XOR = 32'h1000, _OR = 32'h2000, _AND = 32'h4000, SLL = 32'h8000, SRL = 32'h10000,
                              SLT = 32'h20000, LB = 32'h40000, LH = 32'h80000, LW = 32'h100000, SB = 32'h200000, SH = 32'h400000, SW = 32'h800000,
                              JAL = 32'h1000000, JALR = 32'h2000000, BEQ = 32'h4000000 ,BEN = 32'h8000000, BLT = 32'h10000000, BGE = 32'h20000000, 
-	                         BLTU = 32'h40000000, BGEU = 32'h80000000} operations;
+	                         BLTU = 32'h40000000, BGEU = 32'h80000000} e_operations;
+    
+    //inst_decode wires
+    wire[11:0] imm_I; 
+    wire[6:0] imm_S, imm_B;
+    wire[19:0] imm_U, imm_J;
+    wire [4:0] rd, rs1, rs2;
+    wire jump_ops;
+    
+    //signextended in multiples of two(first two LSB killed)
+    wire[31:0] sig_imm_I = { { 21{imm_I[11]} }, imm_I [11:1]};  
+    wire[31:0] sig_imm_B = {{25{1'b0}},imm_B[6:1]}; 
+    wire[31:0] sig_imm_J = { { 13{imm_J[19]} }, imm_J[19:1]};
     
     localparam c_register_file_len = 5; // rv32i has 31 general-purpose registers x1-x31, which hold integer values
     //register file
     bit [31:0] REG_FILE [c_register_file_len - 1 : 0];
     //program counter -> PC
-    bit [31:0] PC = 32'd0;
+    reg [31:0] PC = 32'd0;
     //instruction reg -> INST_REG
     bit [31:0] INST_REG = 32'd0;
     
-    wire [31:0] PC_plus_4 = PC + 4;
-    
-    //R-type instruction parts decoder
-    wire [6:0] opcode = data_in_inst [6:0];
-    wire [4:0] rd = data_in_inst [11:7];
-    wire [2:0] funct3 = data_in_inst [14:12];
-    wire [4:0] rs1 = data_in_inst [19:15];
-    wire [4:0] rs2 = data_in_inst [24:20];
-    wire [6:0] funct7 = data_in_inst [31:25];
-    //immediate decoder
-    wire [11:0] imm_I = data_in_inst[31:20];
-    wire [6:0] imm_S = {data_in_inst[31:25], data_in_inst[11:7]};
-    wire [6:0] imm_B = {data_in_inst[31], data_in_inst[7], data_in_inst[30:25], data_in_inst[11:8]};
-    wire [19:0] imm_U = data_in_inst [31:12];
-    wire [19:0] imm_J = {data_in_inst [31], data_in_inst[19:12], data_in_inst[20], data_in_inst[30:25], data_in_inst[24:21]};
- 
- //instruction format decode
-    //Integer Register-Immediate Instructions (I-type operations)
-    wire imm_alu_op = (opcode == 7'b0010011); 
-    //Integer Register-Register Operations
-    wire reg_alu_op = (opcode == 7'b0110011); 
-    //NOP 
-    //?? 
-	
-    //Conditional branches
-    wire branch_op = (opcode == 7'b1100011);
-    //Load and store instructions
-    wire load_op = (opcode == 7'b0000011);
-    wire store_op = (opcode == 7'b0100011);
-    
-//instruction decode    
-    //immediate    
-    wire _addi =  imm_alu_op & (funct3 == 3'h0); // add immediate
-    wire _slti = imm_alu_op & (funct3 == 3'h2); // set less then immediate
-    wire _andi = imm_alu_op & (funct3 == 3'h7); // and immediate
-    wire _ori = imm_alu_op & (funct3 == 3'h6); // or immediate
-    wire _xori = imm_alu_op & (funct3 == 3'h4); // xor immediate
-    wire _lui = (opcode == 7'b0110111); // load upper immediate
-    wire _auipc = (opcode == 7'b0010111); // // add upper immediate to PC
-    wire _slli = imm_alu_op & (funct3 == 3'h1) & (imm_I[11:5] == 7'h00); //shift left logical immediate
-    wire _srli = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h00); //shift right logical immediate
-    wire _srai = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h20); //shift right arithmetic immediate
-    //register to register alu ops
-    wire _add = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h00); //add rs1 and rs2
-    wire _sub = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h20); //sub rs1 and rs2
-    wire __xor = reg_alu_op & (funct3 == 3'h4) & (funct7 == 7'h00); //xor rs1 and rs2
-    wire __or = reg_alu_op & (funct3 == 3'h6) & (funct7 == 7'h00); //or rs1 and rs2
-    wire __and = reg_alu_op & (funct3 == 3'h7) & (funct7 == 7'h00); //and rs1 and rs2
-    wire _sll = reg_alu_op & (funct3 == 3'h1) & (funct7 == 7'h00); //shift left logical rs1 and rs2
-    wire _srl = reg_alu_op & (funct3 == 3'h5) & (funct7 == 7'h00); //shift right logical rs1 and rs2
-    wire _slt = reg_alu_op & (funct3 == 3'h2) & (funct7 == 7'h00); //set les then if rs1 is less then imm
-    //load
-    wire _lb = load_op & (funct3 == 3'h0); //load byte
-    wire _lh = load_op & (funct3 == 3'h1); //load half word
-    wire _lw = load_op & (funct3 == 3'h2); //load word
-    //store
-    wire _sb = store_op & (funct3 == 3'h0); //store byte
-    wire _sh = store_op & (funct3 == 3'h1); //store half word
-    wire _sw = store_op & (funct3 == 3'h2); //store word
-    //control
-	//Unconditional jumps
-    wire _jal = (opcode == 7'b1101111);
-    wire _jalr = (opcode == 7'b1100111) & (funct3 == 3'h7);
-    //branch
-	wire _beq = branch_op & (funct3 == 3'h0); //branch if equale
-	wire _ben = branch_op & (funct3 == 3'h1); //branch if not equale
-	wire _blt = branch_op & (funct3 == 3'h4); //branch if less then zero
-	wire _bge = branch_op & (funct3 == 3'h5); //branch greater or equale
-	wire _bltu = branch_op & (funct3 == 3'h6); //brench if less then *unsigned
-	wire _bgeu = branch_op & (funct3 == 3'h7); //branch if greater or equale then *unsigned
-	
-	//decode into vector 
-	bit [31:0] operation = {_addi, _slti, _andi, _ori, _xori, _lui, _auipc, _slli, _srli, _srai, _add, _sub,
-	                        __xor, __or, __and, _sll, _srl, _slt, _lb, _lh, _lw, _sb, _sh, _sw, _jal, _jalr, 
-	                        _beq ,_ben, _blt, _bge, _bltu, _bgeu}; 
 	//TO DO: FENCE, FENCE.1, ECALL, EBREAK
 	
-	//setting two regfile outputs
-	wire [31:0] qa = (rs1==0) ? 0 : REG_FILE[rs1];
-    wire [31:0] qb = (rs2==0) ? 0 : REG_FILE[rs2];
+	//setting regfile readports
+    reg [31:0] qa;
+	reg [31:0] qb;
 	
-	//set operation registers
-	bit [31:0] a;
-	bit [31:0] b;
-	bit [31:0] c;
+    //registes for extra control  
+	logic [31:0] current_PC;
+	logic [31:0] c;
 	
 	//load store wires
 	bit [31:0] _addr_data  = 32'b0;
-	bit [3:0]  _we_data = 4'b0000;
+	bit [2:0]  _we_data = 4'b0000;
 	
-	//state machine
-	
-    //main state machine
-    always@(posedge aclk)begin
-           //assign enum to state tracker 
-           e_states T;
-           operations operation;  
-           if(aresetn)begin //work
-               case(T)
-                    FETCH : begin //INSTR fetch
-                        INST_REG <= data_in_inst;
-                        T <= T.next();
-                        PC <= PC_plus_4;                          
-                    end
-                    DECODE : begin //INSTR decode
-                        if(imm_alu_op | reg_alu_op | branch_op )begin //in case of ALU and branch instructions
-                            a <= qa;
-                            b <= qb;
-                            c <= $signed({20{imm_B[31], imm_B}});
-                            T = EXECUTE;
-                        end else begin
-                            case (1'b1)
+	//decode settings
+	bit [31:0] next_PC; //next_PC wire
+	bit [4:0] dest_rn = rd; //TODO: redundant 
+	logic [31:0] a; //adder port A TODO: rename to alu_B
+	logic [31:0] b;  //adder port B TODO: rename to alu_B
+	logic [31:0] ALU_out; //adder out port     
+	//muxes and alu combo
+	    
+	      
+	      
+	      
+	  
+	 //assign enum to state tracker 
+     e_states T;
+     e_operations operation;
+    //combinational part - muxes (no registers or elements with clock)        
+    always@(T, operation)begin
+    //set defult states for no latches
+        next_PC <= ALU_out;
+        a <= PC;
+        b <= 31'd4;
+        ALU_out <= a + b;
+    //work part     
+	   case(T)
+	       FETCH:begin
+	           next_PC <= ALU_out;
+               a <= PC;
+               b <= 31'd4;
+               ALU_out <= a + b; //set all for PC = PC + 4    
+	       end
+	       DECODE:begin
+	           if(jump_ops)begin //in case of ALU and branch instructions
+                            case (operation)
                                 JAL:begin
-				    if(rd == 1'b0)begin //pseudo-instruction jump 1 cycle
-                               	        PC <= PC + $signed({12{imm_J[31], imm_J}});
-                                	T <= DECODE;
-				    end	else begin //JAL part
-					c <= PC_plus_4;
-					PC <= PC + $signed({12{imm_J[31], imm_J}});
-					T <= WRITE_BACK;
-				    end	
+									if(dest_rn == 1'b0)begin //pseudo-instruction jump 1 cycle
+                                        a <= PC;
+                                        b <=  sig_imm_J;
+								        ALU_out <= a + b; // set all for PC = PC + imm_J (sequential part goes to fetch) 
+								    end	else begin //JAL part
+								        b <=  sig_imm_J;
+								        a <= current_PC; //TODO:check might be wrong
+										ALU_out <= a + b; //set all for PC = PC + imm_J  (sequential part goes to execute)
+								    end	
                                 end
                                 JALR:begin
-                                     c <= PC_plus_4;
-                                     PC <= qa + {20{imm_I[31], imm_I}};
-                                     T <= MEMORY;
+                                    //TODO: This is incomplete
+                                    ALU_out <= a + b;
                                 end
-                                AUIPC: ;
+                                AUIPC: begin 
+                                    //PC <= PC + {imm_U,{12'b0}}; //U-immediate in register rd (lowest 12 bits are zeroes) TODO: check!
+                                end
+                                LUI: begin
+                                    //c <= {imm_U,{12'b0}}; //U-immediate in register rd (lowest 12 bits are zeroes)  TODO: check!
+                                end
                             endcase
-                        end
-                           
-                    end
-                    EXECUTE: begin // INSTR exe
-                        case(operation) //change to opcode when inst decode is completed
+                        end else begin
+                                           //no combinational for this part
+                        end                      
+	       end
+	       EXECUTE: begin
+                case(operation) //change to opcode when inst decode is completed
                             //immediate integer operations
-                            ADDI: begin 
-                                c <= a + {{20{imm_I[31]}}, imm_I}; //arithmetic ops are just signe-extended to 32 bits
-                                T <= WRITE_BACK;
+                            ADDI: begin
+                                a <= qa;
+                                b <= sig_imm_I;
+                                ALU_out <= a + b; //set for c = qa + imm_I (c is register that is rewired in sequential part)
                             end
-                            SLTI: begin
-                                c <= $signed(a) < $signed({20{imm_I[31], imm_I}}); //logic operations need $signed function
+                            SLTI: begin //writes 1 or 0 to reg[rd] depending on a<b 
+                                a <= qa;
+                                b <= sig_imm_I;
+                                ALU_out <= $signed(a) < $signed(b); //set c = qa < imm_I (logic operations need $signed function)
                             end
                             SRLI: ;
                             SRAI: ;
@@ -183,11 +141,14 @@ module cpu_top(
                             ORI: ;
                             XORI: ; //note, XORI rd, rs1, -1 performs a bitwise logical inversion of register rs1 (assembler pseudo-instruction NOT rd, rs) 
                             LUI: ;
-                            AUIPC: ;
+                            AUIPC:begin 
+                                // ALU_out <= PC; TODO
+                            end
                             //Register-Register operations
                             ADD: begin
-                                c <= a + b;
-                                T <= WRITE_BACK;
+                                a <= qa;
+                                b <= qb;
+                                ALU_out <= a + b; //set registers for c = a + b (c is register that is rewired in sequential part)
                             end            
                             SUB: ;
                             _XOR: ;
@@ -196,31 +157,122 @@ module cpu_top(
                             SRL: ;
                             SLL: ;
                             SLT: ;
-	                   //store instruction adress calculation 
-			   (SB | SW | SH):begin 
-					     _addr_data <= a + {20{imm_I[31], imm_I}};
-					     T = MEMORY;
-					 end    
-			   JALR: begin 
-			         PC[0] <= 0; 
-			         T <= WRITE_BACK;
-			    end 
+							//store instruction adress calculation 
+							(SB | SW | SH):begin
+							     a <= qa;
+							     b <= sig_imm_I; 
+							     ALU_out <= a + b;
+							 end    
+							JALR: begin // TODO
+						    end 
+                        endcase	
+           end                     
+	       MEMORY: ;
+	   endcase
+	end  
+    //
+    //
+    //     SEQUENTIAL LOGIC PART
+    //
+    //    
+    always@(posedge aclk)begin 
+           if(aresetn)begin //work
+               case(T)
+                    FETCH : begin //INSTR fetch
+                        INST_REG <= data_in_inst;
+                        current_PC <= PC; //save current PC to register for control instructions 
+                        PC <= next_PC; //save next_PC to PC
+                        T <= DECODE;               
+                    end
+                    DECODE : begin //INSTR decode
+                        if(jump_ops)begin //in case of ALU and branch instructions
+                            case (operation)
+                                JAL:begin
+									if(dest_rn == 1'b0)begin //pseudo-instruction jump 1 cycle
+									   next_PC <= ALU_out;  //this is actually comb
+                                       T <= FETCH;                             
+								    end	else begin //JAL part
+								       next_PC <= ALU_out; //this is actually comb
+									   T <= EXECUTE;
+								    end	
+                                end
+                                JALR:begin
+                                    T <= MEMORY; // TODO: not done
+                                end
+                                AUIPC: begin 
+                                    T <= EXECUTE; // TODO: not done
+                                end
+                                LUI: begin
+                                    T <= WRITE_BACK; // TODO: not done
+                                end
+                            endcase
+                        end else begin // in case of ALU r to r 
+                            //setting regfile readports for ALU operations
+                            qa <= (rs1==0) ? 0 : REG_FILE[rs1];
+                        	qb <= (rs2==0) ? 0 : REG_FILE[rs2];
+                            T <= EXECUTE;                            
+                        end
+                           
+                    end
+                    EXECUTE: begin // INSTR exe                    
+                        case(operation) //change to opcode when inst decode is completed
+                            //immediate integer operations
+                            ADDI: begin
+                                c <= ALU_out; 
+                                T <= WRITE_BACK; //load and go to write
+                            end
+                            SLTI: begin
+                                c <= ALU_out;
+                                T <= WRITE_BACK; //load and go to write
+                            end
+                            SRLI: ;
+                            SRAI: ;
+                            ANDI: ;
+                            ORI: ;
+                            XORI: ; //note, XORI rd, rs1, -1 performs a bitwise logical inversion of register rs1 (assembler pseudo-instruction NOT rd, rs) 
+                            LUI: ;
+                            AUIPC:begin
+                                 c <= ALU_out; 
+                                 T <= WRITE_BACK; //load and go to write
+                            end
+                            //Register-Register operations
+                            ADD: begin
+                                c <= ALU_out;
+                                T <= WRITE_BACK; //load and go to write
+                            end            
+                            SUB: ;
+                            _XOR: ;
+                            _OR: ;
+                            _AND: ;
+                            SRL: ;
+                            SLL: ;
+                            SLT: ;
+							//store instruction adress calculation 
+							(SB | SW | SH):begin 
+                                 c = ALU_out;
+							     T = MEMORY; //load and go to write
+							 end    
+							JALR: begin 
+//						         PC[0] <= 0; 
+						         T <= WRITE_BACK; //load and go to write
+						    end 
                         endcase
                     end
                     MEMORY: begin //memory access state
-                        case (operation)
-                            SB: _we_data <= 4'b0001;                                
-                            SH: _we_data <= 4'b0011;
-                            SW: _we_data <= 4'b1111;
-                            //Load
-                            LB: REG_FILE[rd] <= {{24{data_in_data[31]}},data_in_data[31:24]};
-                            LH: REG_FILE[rd] <= {{16{data_in_data[31]}},data_in_data[31:16]};
-                            LW: REG_FILE[rd] <= data_in_data;
-                         endcase
+                    //TO DO: this needs to be redone but this is general scheme
+                //                        case (operation)
+//                            SB: _we_data <= 4'b0001;                                
+//                            SH: _we_data <= 4'b0011;
+//                            SW: _we_data <= 4'b1111;
+//                            //Load
+//                            LB: REG_FILE[dest_rn] <= {{24{data_in_data[31]}},data_in_data[31:24]};
+//                            LH: REG_FILE[dest_rn] <= {{16{data_in_data[31]}},data_in_data[31:16]};
+//                            LW: REG_FILE[dest_rn] <= data_in_data;
+//                         endcase
                          T <= FETCH;        
                     end
                     WRITE_BACK: begin // write back state
-                        REG_FILE[rd] = c;
+                        REG_FILE[dest_rn] <= c; //write back and go to first state
                         T <= FETCH;
                     end
                endcase
@@ -234,9 +286,20 @@ module cpu_top(
     
     //net assigments
     assign addr_inst = PC[31:3]; //use word adress to read memory
-    assign REG_FILE[0] = 32'h00; //register x0 is hardwired to the constant
-    assign we_data = _we_data;
-    assign addr_data = _addr_data;
+	assign REG_FILE[0] = 32'h00; //register x0 is hardwired to the constant
+	assign we_data = _we_data;
+	assign addr_data = _addr_data;
+	
+	//instantiations
+	 inst_decode my_inst( .data_in_inst,
+     .operation,
+     .imm_I, 
+     .imm_S , .imm_B ,
+     .imm_U , .imm_J,
+     .rd, .rs1, .rs2,
+     .jump_ops
+     );
+
 
 	
 endmodule

--- a/cpu_top.sv
+++ b/cpu_top.sv
@@ -16,7 +16,9 @@ module cpu_top(
     output [31:0] data_out_data,
     input [31:0] data_in_data,
     output en_data,
-    output [3:0] we_data 
+    output [3:0] we_data
+    //decode instruction module
+    
     );
     
     

--- a/cpu_top.sv
+++ b/cpu_top.sv
@@ -1,5 +1,6 @@
 `timescale 1ns / 1ps
 
+
 module cpu_top(
     //clocking
     input aclk,
@@ -18,7 +19,13 @@ module cpu_top(
     output [3:0] we_data
     );
     
-    
+    //state machine enum
+    typedef enum bit [2:0] {FETCH,DECODE,EXECUTE,MEMORY,WRITE_BACK} e_states;
+    typedef enum bit [31:0] {ADDI = 32'h1, SLTI = 32'h2, ANDI = 32'h4, ORI = 32'h8, XORI = 32'h10, LUI = 32'h20, AUIPC = 32'h40, SLLI = 32'h80, SRLI = 32'h100,
+                             SRAI = 32'h200, ADD = 32'h400, SUB = 32'h800,_XOR = 32'h1000, _OR = 32'h2000, _AND = 32'h4000, SLL = 32'h8000, SRL = 32'h10000,
+                             SLT = 32'h20000, LB = 32'h40000, LH = 32'h80000, LW = 32'h100000, SB = 32'h200000, SH = 32'h400000, SW = 32'h800000,
+                             JAL = 32'h1000000, JALR = 32'h2000000, BEQ = 32'h4000000 ,BEN = 32'h8000000, BLT = 32'h10000000, BGE = 32'h20000000, 
+	                         BLTU = 32'h40000000, BGEU = 32'h80000000} operations;
     
     localparam c_register_file_len = 5; // rv32i has 31 general-purpose registers x1-x31, which hold integer values
     //register file
@@ -27,12 +34,7 @@ module cpu_top(
     bit [31:0] PC = 32'd0;
     //instruction reg -> INST_REG
     bit [31:0] INST_REG = 32'd0;
-    //state tracker
-    bit [31:0] T = 'd0;
-//next pc 
-//    bit [31:0] next_PC; 
-
-    //PC + 4
+    
     wire [31:0] PC_plus_4 = PC + 4;
     
     //R-type instruction parts decoder
@@ -65,158 +67,176 @@ module cpu_top(
     
 //instruction decode    
     //immediate    
-    wire addi =  imm_alu_op & (funct3 == 3'h0); // add immediate
-    wire slti = imm_alu_op & (funct3 == 3'h2); // set less then immediate
-    wire andi = imm_alu_op & (funct3 == 3'h7); // and immediate
-    wire ori = imm_alu_op & (funct3 == 3'h6); // or immediate
-    wire xori = imm_alu_op & (funct3 == 3'h4); // xor immediate
-    wire lui = (opcode == 7'b0110111); // load upper immediate
-    wire auipc = (opcode == 7'b0010111); // // add upper immediate to PC
-    wire slli = imm_alu_op & (funct3 == 3'h1) & (imm_I[11:5] == 7'h00); //shift left logical immediate
-    wire srli = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h00); //shift right logical immediate
-    wire srai = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h20); //shift right arithmetic immediate
+    wire _addi =  imm_alu_op & (funct3 == 3'h0); // add immediate
+    wire _slti = imm_alu_op & (funct3 == 3'h2); // set less then immediate
+    wire _andi = imm_alu_op & (funct3 == 3'h7); // and immediate
+    wire _ori = imm_alu_op & (funct3 == 3'h6); // or immediate
+    wire _xori = imm_alu_op & (funct3 == 3'h4); // xor immediate
+    wire _lui = (opcode == 7'b0110111); // load upper immediate
+    wire _auipc = (opcode == 7'b0010111); // // add upper immediate to PC
+    wire _slli = imm_alu_op & (funct3 == 3'h1) & (imm_I[11:5] == 7'h00); //shift left logical immediate
+    wire _srli = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h00); //shift right logical immediate
+    wire _srai = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h20); //shift right arithmetic immediate
     //register to register alu ops
-    wire add = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h00); //add rs1 and rs2
-    wire sub = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h20); //sub rs1 and rs2
-    wire _xor = reg_alu_op & (funct3 == 3'h4) & (funct7 == 7'h00); //xor rs1 and rs2
-    wire _or = reg_alu_op & (funct3 == 3'h6) & (funct7 == 7'h00); //or rs1 and rs2
-    wire _and = reg_alu_op & (funct3 == 3'h7) & (funct7 == 7'h00); //and rs1 and rs2
-    wire sll = reg_alu_op & (funct3 == 3'h1) & (funct7 == 7'h00); //shift left logical rs1 and rs2
-    wire srl = reg_alu_op & (funct3 == 3'h5) & (funct7 == 7'h00); //shift right logical rs1 and rs2
-    wire slt = reg_alu_op & (funct3 == 3'h2) & (funct7 == 7'h00); //set les then if rs1 is less then imm
+    wire _add = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h00); //add rs1 and rs2
+    wire _sub = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h20); //sub rs1 and rs2
+    wire __xor = reg_alu_op & (funct3 == 3'h4) & (funct7 == 7'h00); //xor rs1 and rs2
+    wire __or = reg_alu_op & (funct3 == 3'h6) & (funct7 == 7'h00); //or rs1 and rs2
+    wire __and = reg_alu_op & (funct3 == 3'h7) & (funct7 == 7'h00); //and rs1 and rs2
+    wire _sll = reg_alu_op & (funct3 == 3'h1) & (funct7 == 7'h00); //shift left logical rs1 and rs2
+    wire _srl = reg_alu_op & (funct3 == 3'h5) & (funct7 == 7'h00); //shift right logical rs1 and rs2
+    wire _slt = reg_alu_op & (funct3 == 3'h2) & (funct7 == 7'h00); //set les then if rs1 is less then imm
     //load
-    wire lb = load_op & (funct3 == 3'h0); //load byte
-    wire lh = load_op & (funct3 == 3'h1); //load half word
-    wire lw = load_op & (funct3 == 3'h2); //load word
+    wire _lb = load_op & (funct3 == 3'h0); //load byte
+    wire _lh = load_op & (funct3 == 3'h1); //load half word
+    wire _lw = load_op & (funct3 == 3'h2); //load word
     //store
-    wire sb = store_op & (funct3 == 3'h0); //store byte
-    wire sh = store_op & (funct3 == 3'h1); //store half word
-    wire sw = store_op & (funct3 == 3'h2); //store word
+    wire _sb = store_op & (funct3 == 3'h0); //store byte
+    wire _sh = store_op & (funct3 == 3'h1); //store half word
+    wire _sw = store_op & (funct3 == 3'h2); //store word
     //control
 	//Unconditional jumps
-    wire jal = (opcode == 7'b1101111);
-    wire jalr = (opcode == 7'b1100111) & (funct3 == 3'h7);
+    wire _jal = (opcode == 7'b1101111);
+    wire _jalr = (opcode == 7'b1100111) & (funct3 == 3'h7);
     //branch
-	wire beq = branch_op & (funct3 == 3'h0); //branch if equale
-	wire ben = branch_op & (funct3 == 3'h1); //branch if not equale
-	wire blt = branch_op & (funct3 == 3'h4); //branch if less then zero
-	wire bge = branch_op & (funct3 == 3'h5); //branch greater or equale
-	wire bltu = branch_op & (funct3 == 3'h6); //brench if less then *unsigned
-	wire bgeu = branch_op & (funct3 == 3'h7); //branch if greater or equale then *unsigned 
+	wire _beq = branch_op & (funct3 == 3'h0); //branch if equale
+	wire _ben = branch_op & (funct3 == 3'h1); //branch if not equale
+	wire _blt = branch_op & (funct3 == 3'h4); //branch if less then zero
+	wire _bge = branch_op & (funct3 == 3'h5); //branch greater or equale
+	wire _bltu = branch_op & (funct3 == 3'h6); //brench if less then *unsigned
+	wire _bgeu = branch_op & (funct3 == 3'h7); //branch if greater or equale then *unsigned
+	
+	//decode into vector 
+	bit [31:0] operation = {_addi, _slti, _andi, _ori, _xori, _lui, _auipc, _slli, _srli, _srai, _add, _sub,
+	                        __xor, __or, __and, _sll, _srl, _slt, _lb, _lh, _lw, _sb, _sh, _sw, _jal, _jalr, 
+	                        _beq ,_ben, _blt, _bge, _bltu, _bgeu}; 
 	//TO DO: FENCE, FENCE.1, ECALL, EBREAK
 	
 	//setting two regfile outputs
-	wire [31:0] qa <= (rs1==0) ? 0 : REG_FILE[rs1];
-    wire [31:0] qb <= (rs2==0) ? 0 : REG_FILE[rs2];
+	wire [31:0] qa = (rs1==0) ? 0 : REG_FILE[rs1];
+    wire [31:0] qb = (rs2==0) ? 0 : REG_FILE[rs2];
 	
 	//set operation registers
-	reg [31:0] a;
-	reg [31:0] b;
-	reg [31:0] c;
+	bit [31:0] a;
+	bit [31:0] b;
+	bit [31:0] c;
 	
 	//load store wires
-	wire [31:0] address  = 32'b0;
-	wire [3:0] write_enable = 4'b0000;
+	bit [31:0] _addr_data  = 32'b0;
+	bit [3:0]  _we_data = 4'b0000;
+	
+	//state machine
 	
     //main state machine
     always@(posedge aclk)begin
+           //assign enum to state tracker 
+           e_states T;
+           operations operation;  
            if(aresetn)begin //work
-                T <= T + 1;
                case(T)
-                    32'd0 : begin //INSTR fetch
+                    FETCH : begin //INSTR fetch
                         INST_REG <= data_in_inst;
-                        T <= T + 1;
-//                        PC <= next_PC;
+                        T <= T.next();
                         PC <= PC_plus_4;                          
                     end
-                    32'd1 : begin //INSTR decode
+                    DECODE : begin //INSTR decode
                         if(imm_alu_op | reg_alu_op | branch_op )begin //in case of ALU and branch instructions
-                            a <= qa
-                            b <= qb
+                            a <= qa;
+                            b <= qb;
                             c <= $signed({20{imm_B[31], imm_B}});
-                            T <= T + 1;
+                            T = EXECUTE;
                         end else begin
                             case (1'b1)
-                                jal:begin
-									if(rd == 1'b0)begin //pseudo-instruction jump 1 cycle
-                                        PC <= PC + $signed({12{imm_J[31], imm_J}});
-                                        T <= 0;
-									end	else begin //JAL part
-										c <= PC_plus_4;
-										PC <= PC + $signed({12{imm_J[31], imm_J}});
-										T <= T + 2;
-									end
-										
+                                JAL:begin
+				    if(rd == 1'b0)begin //pseudo-instruction jump 1 cycle
+                               	        PC <= PC + $signed({12{imm_J[31], imm_J}});
+                                	T <= DECODE;
+				    end	else begin //JAL part
+					c <= PC_plus_4;
+					PC <= PC + $signed({12{imm_J[31], imm_J}});
+					T <= WRITE_BACK;
+				    end	
                                 end
-                                jalr:begin
-                                        c <= PC_plus_4;
-                                        PC <= qa + {20{imm_I[31], imm_I}};
-                                        T <= T + 2;
-                                    end
-                                auipc: ;
+                                JALR:begin
+                                     c <= PC_plus_4;
+                                     PC <= qa + {20{imm_I[31], imm_I}};
+                                     T <= MEMORY;
+                                end
+                                AUIPC: ;
                             endcase
                         end
                            
                     end
-                    32'd2: begin // INSTR exe
-                        case(1'b1) //change to opcode when inst decode is completed
+                    EXECUTE: begin // INSTR exe
+                        case(operation) //change to opcode when inst decode is completed
                             //immediate integer operations
-                            (imm_alu_op | reg_alu_op): T <= T + 2;				
-                            addi: c <= a + {{20{imm_I[31]}}, imm_I}; //arithmetic ops are just signe-extended to 32 bits
-                            slti: c <= $signed(a) < $signed({20{imm_I[31], imm_I}}); //logic operations need $signed function
-                            srli: ;
-                            srai: ;
-                            andi: ;
-                            ori: ;
-                            xori: ; //note, XORI rd, rs1, -1 performs a bitwise logical inversion of register rs1 (assembler pseudo-instruction NOT rd, rs) 
-                            lui: ;
-                            auipc: ;
+                            ADDI: begin 
+                                c <= a + {{20{imm_I[31]}}, imm_I}; //arithmetic ops are just signe-extended to 32 bits
+                                T <= WRITE_BACK;
+                            end
+                            SLTI: begin
+                                c <= $signed(a) < $signed({20{imm_I[31], imm_I}}); //logic operations need $signed function
+                            end
+                            SRLI: ;
+                            SRAI: ;
+                            ANDI: ;
+                            ORI: ;
+                            XORI: ; //note, XORI rd, rs1, -1 performs a bitwise logical inversion of register rs1 (assembler pseudo-instruction NOT rd, rs) 
+                            LUI: ;
+                            AUIPC: ;
                             //Register-Register operations
-                            add: c <= a + b;
-                            sub: ;
-                            _xor: ;
-                            _or: ;
-                            _and: ;
-                            srl: ;
-                            sll: ;
-                            slt: ;
-							//store instruction adress calculation 
-							(sb | sw | sh):	address <= a + {20{imm_I[31], imm_I}};
-                            //load-store
-                            (load_op | store_op): T <= T + 1; //jump to mem cycle
-							jalr:begin PC[0] <= 0; T <= T + 2;  end 
+                            ADD: begin
+                                c <= a + b;
+                                T <= WRITE_BACK;
+                            end            
+                            SUB: ;
+                            _XOR: ;
+                            _OR: ;
+                            _AND: ;
+                            SRL: ;
+                            SLL: ;
+                            SLT: ;
+	                   //store instruction adress calculation 
+			   (SB | SW | SH):begin 
+					     _addr_data <= a + {20{imm_I[31], imm_I}};
+					     T = MEMORY;
+					 end    
+			   JALR: begin 
+			         PC[0] <= 0; 
+			         T <= WRITE_BACK;
+			    end 
                         endcase
                     end
-                    32'd3: begin //memory access state
-                        T <= 0;
-                        case (1'b1)
-                            sb: write_enable <= 4'b0001;                                
-                            sh: write_enable <= 4'b0011;
-                            sw: write_enable <= 4'b1111;
+                    MEMORY: begin //memory access state
+                        case (operation)
+                            SB: _we_data <= 4'b0001;                                
+                            SH: _we_data <= 4'b0011;
+                            SW: _we_data <= 4'b1111;
                             //Load
-                            lb: REG_FILE[rd] <= {{24{data_in_data[31]}},data_in_data[31:24]};
-                            lh: REG_FILE[rd] <= {{16{data_in_data[31]}},data_in_data[31:16]};
-                            lw: REG_FILE[rd] <= data_in_data;
-                         endcase        
+                            LB: REG_FILE[rd] <= {{24{data_in_data[31]}},data_in_data[31:24]};
+                            LH: REG_FILE[rd] <= {{16{data_in_data[31]}},data_in_data[31:16]};
+                            LW: REG_FILE[rd] <= data_in_data;
+                         endcase
+                         T <= FETCH;        
                     end
-                    32'd4: begin // write back state
+                    WRITE_BACK: begin // write back state
                         REG_FILE[rd] = c;
-                        T <= 0;
+                        T <= FETCH;
                     end
                endcase
                
            end
            else begin       //reset
                 PC <= 32'd0;
-                T <= 32'd0;
+                T <= FETCH;
            end
     end
     
     //net assigments
     assign addr_inst = PC[31:3]; //use word adress to read memory
-	assign REG_FILE[31] = 32'h00; //register x0 is hardwired to the constant
-	assign we_data = write_enable;
-	assign addr_data = adress;
+    assign REG_FILE[0] = 32'h00; //register x0 is hardwired to the constant
+    assign we_data = _we_data;
+    assign addr_data = _addr_data;
 
 	
 endmodule

--- a/decoder.sv
+++ b/decoder.sv
@@ -1,0 +1,119 @@
+`timescale 1ns / 1ps
+
+module inst_decode(
+    input[31:0]  data_in_inst,
+    output[31:0] operation,
+    output[11:0] imm_I, 
+    output[6:0] imm_S, imm_B,
+    output[19:0] imm_U, imm_J,
+    output [4:0] rd, rs1, rs2,
+    output jump_ops
+    );
+    typedef enum bit [31:0] {ADDI = 32'h1, SLTI = 32'h2, ANDI = 32'h4, ORI = 32'h8, XORI = 32'h10, LUI = 32'h20, AUIPC = 32'h40, SLLI = 32'h80, SRLI = 32'h100,
+                             SRAI = 32'h200, ADD = 32'h400, SUB = 32'h800,_XOR = 32'h1000, _OR = 32'h2000, _AND = 32'h4000, SLL = 32'h8000, SRL = 32'h10000,
+                             SLT = 32'h20000, LB = 32'h40000, LH = 32'h80000, LW = 32'h100000, SB = 32'h200000, SH = 32'h400000, SW = 32'h800000,
+                             JAL = 32'h1000000, JALR = 32'h2000000, BEQ = 32'h4000000 ,BEN = 32'h8000000, BLT = 32'h10000000, BGE = 32'h20000000, 
+	                         BLTU = 32'h40000000, BGEU = 32'h80000000} e_operations;
+    
+    
+    //R-type instruction parts decoder
+    wire [6:0] opcode = data_in_inst [6:0];
+    wire [4:0] _rd = data_in_inst [11:7];
+    wire [2:0] funct3 = data_in_inst [14:12];
+    wire [4:0] _rs1 = data_in_inst [19:15];
+    wire [4:0] _rs2 = data_in_inst [24:20];
+    wire [6:0] funct7 = data_in_inst [31:25];
+    //immediate decoder
+    wire [11:0] _imm_I = data_in_inst[31:20];
+    wire [6:0] _imm_S = {data_in_inst[31:25], data_in_inst[11:7]};
+    wire [6:0] _imm_B = {data_in_inst[31], data_in_inst[7], data_in_inst[30:25], data_in_inst[11:8]};
+    wire [19:0] _imm_U = data_in_inst [31:12];
+    wire [19:0] _imm_J = {data_in_inst [31], data_in_inst[19:12], data_in_inst[20], data_in_inst[30:25], data_in_inst[24:21]};
+ 
+ //instruction format decode
+    //Integer Register-Immediate Instructions (I-type operations)
+    wire imm_alu_op = (opcode == 7'b0010011); 
+    //Integer Register-Register Operations
+    wire reg_alu_op = (opcode == 7'b0110011); 
+    //NOP 
+    //?? 
+	
+    //Conditional branches
+    wire branch_op = (opcode == 7'b1100011);
+    //Load and store instructions
+    wire load_op = (opcode == 7'b0000011);
+    wire store_op = (opcode == 7'b0100011);
+    
+//instruction decode    
+    //immediate    
+    wire _addi =  imm_alu_op & (funct3 == 3'h0); // add immediate
+    wire _slti = imm_alu_op & (funct3 == 3'h2); // set less then immediate
+    wire _andi = imm_alu_op & (funct3 == 3'h7); // and immediate
+    wire _ori = imm_alu_op & (funct3 == 3'h6); // or immediate
+    wire _xori = imm_alu_op & (funct3 == 3'h4); // xor immediate
+    wire _lui = (opcode == 7'b0110111); // load upper immediate
+    wire _auipc = (opcode == 7'b0010111); // // add upper immediate to PC
+    wire _slli = imm_alu_op & (funct3 == 3'h1) & (imm_I[11:5] == 7'h00); //shift left logical immediate
+    wire _srli = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h00); //shift right logical immediate
+    wire _srai = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h20); //shift right arithmetic immediate
+    //register to register alu ops
+    wire _add = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h00); //add rs1 and rs2
+    wire _sub = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h20); //sub rs1 and rs2
+    wire __xor = reg_alu_op & (funct3 == 3'h4) & (funct7 == 7'h00); //xor rs1 and rs2
+    wire __or = reg_alu_op & (funct3 == 3'h6) & (funct7 == 7'h00); //or rs1 and rs2
+    wire __and = reg_alu_op & (funct3 == 3'h7) & (funct7 == 7'h00); //and rs1 and rs2
+    wire _sll = reg_alu_op & (funct3 == 3'h1) & (funct7 == 7'h00); //shift left logical rs1 and rs2
+    wire _srl = reg_alu_op & (funct3 == 3'h5) & (funct7 == 7'h00); //shift right logical rs1 and rs2
+    wire _slt = reg_alu_op & (funct3 == 3'h2) & (funct7 == 7'h00); //set les then if rs1 is less then imm
+    //load
+    wire _lb = load_op & (funct3 == 3'h0); //load byte
+    wire _lh = load_op & (funct3 == 3'h1); //load half word
+    wire _lw = load_op & (funct3 == 3'h2); //load word
+    //store
+    wire _sb = store_op & (funct3 == 3'h0); //store byte
+    wire _sh = store_op & (funct3 == 3'h1); //store half word
+    wire _sw = store_op & (funct3 == 3'h2); //store word
+    //control
+	//Unconditional jumps
+    wire _jal = (opcode == 7'b1101111);
+    wire _jalr = (opcode == 7'b1100111) & (funct3 == 3'h7);
+    //branch
+	wire _beq = branch_op & (funct3 == 3'h0); //branch if equale
+	wire _ben = branch_op & (funct3 == 3'h1); //branch if not equale
+	wire _blt = branch_op & (funct3 == 3'h4); //branch if less then zero
+	wire _bge = branch_op & (funct3 == 3'h5); //branch greater or equale
+	wire _bltu = branch_op & (funct3 == 3'h6); //brench if less then *unsigned
+	wire _bgeu = branch_op & (funct3 == 3'h7); //branch if greater or equale then *unsigned
+	
+
+	wire _jump_ops = (_jal | _jalr); //select j immedieta
+	
+
+	   
+	
+
+	
+	//operations into vector 
+	bit [31:0] _operation = {_addi, _slti, _andi, _ori, _xori, _lui, _auipc, _slli, _srli, _srai, _add, _sub,
+	                        __xor, __or, __and, _sll, _srl, _slt, _lb, _lh, _lw, _sb, _sh, _sw, _jal, _jalr, 
+	                        _beq ,_ben, _blt, _bge, _bltu, _bgeu};
+	                        
+    //net assignments
+    assign operation = _operation;
+
+    assign imm_I = _imm_I; 
+    assign imm_S = _imm_S;
+    assign imm_B = _imm_B;
+    assign imm_U = _imm_U;
+    assign imm_J = _imm_J;
+    
+    assign rd = _rd;
+    assign rs1 = _rs1;
+    assign rs2 = _rs2;
+
+    assign jump_ops = _jump_ops;
+     
+    
+                            
+    
+endmodule


### PR DESCRIPTION
added 3 group of muxes that as selectors have operation and T signal. First grouup controlles alu input a, second group alu input b, and last group alu output. This ensures that all internal arithmethic and logic operations go trough same alu unit including PC + 4. Implementation of these muxes is done by making seperate combinational always block. All registers are in alwaysblock with aclk. 

Future implementations of instructions should follow this method 
- in combinational block set all signals to correct wires for operations
- in sequential cirucuit write these operations to registers

Additional improvments concerning code readabilty should be considered since we have two almost indentiacl always block.

Additional minor improvments - enum, decoder part is now modul, fixed register x0, imm are now properly signed extended (i have small doubts about this), and other small changes.
