### PR TITLE
Alu

### DIFF
--- a/alu.sv
+++ b/alu.sv
@@ -1,0 +1,31 @@
+`timescale 1ns / 1ps
+
+module alu(
+    input [31:0] a_i, b_i,
+    input [2:0] funct3_i,
+    input funct7_i,
+    output [31:0] c_o,
+    //no pipeline input
+    input pc_add
+    );
+    
+    bit c_i;
+    
+    always_comb begin
+        if (pc_add) c_i = a_i + b_i; // in pipeline cpu pc needs seperate adder to preform fetch add pc, and execute instruction adds in same time
+        else begin
+            case (funct3_i)
+                3'b000: c_i = funct7_i ? (a_i + b_i) : (a_i - b_i); // add / sub
+                3'b001: c_i = a_i << b_i; // sll: rs1 is a_i, b_i is lower 5 bits of I-immidate 
+                3'b010: c_i = a_i < b_i; // slt
+                3'b011: c_i = a_i == b_i;  //sltu
+                3'b100: c_i = a_i ^ b_i; //xor
+                3'b101: c_i = funct7_i ? (a_i >> b_i) : (a_i >>> b_i); //srl / sra
+                3'b110: c_i = a_i | b_i; //or
+                3'b111: c_i = a_i & b_i; //and      
+            endcase
+        end             
+    end
+    
+    
+endmodule

--- a/decoder.sv
+++ b/decoder.sv
@@ -7,7 +7,9 @@ module inst_decode(
     output[6:0] imm_S, imm_B,
     output[19:0] imm_U, imm_J,
     output [4:0] rd, rs1, rs2,
-    output jump_ops
+    output jump_ops,
+    output [3:0] funct3,
+    output funct7
     );
     typedef enum bit [31:0] {ADDI = 32'h1, SLTI = 32'h2, ANDI = 32'h4, ORI = 32'h8, XORI = 32'h10, LUI = 32'h20, AUIPC = 32'h40, SLLI = 32'h80, SRLI = 32'h100,
                              SRAI = 32'h200, ADD = 32'h400, SUB = 32'h800,_XOR = 32'h1000, _OR = 32'h2000, _AND = 32'h4000, SLL = 32'h8000, SRL = 32'h10000,
@@ -19,10 +21,10 @@ module inst_decode(
     //R-type instruction parts decoder
     wire [6:0] opcode = data_in_inst [6:0];
     wire [4:0] _rd = data_in_inst [11:7];
-    wire [2:0] funct3 = data_in_inst [14:12];
+    wire [2:0] _funct3 = data_in_inst [14:12];
     wire [4:0] _rs1 = data_in_inst [19:15];
     wire [4:0] _rs2 = data_in_inst [24:20];
-    wire [6:0] funct7 = data_in_inst [31:25];
+    wire [6:0] _funct7 = data_in_inst [31:25];
     //immediate decoder
     wire [11:0] _imm_I = data_in_inst[31:20];
     wire [6:0] _imm_S = {data_in_inst[31:25], data_in_inst[11:7]};
@@ -112,6 +114,9 @@ module inst_decode(
     assign rs2 = _rs2;
 
     assign jump_ops = _jump_ops;
+    
+    assign funct3 = _funct3;
+    assign funct7 = _funct7[5];
      
     
                             


### PR DESCRIPTION
- added alu modul
- alu opcode is now funct3, funct 7, and add_pc (uses ISA for encoding alu control signal)
- add_pc is added since in non-pipelined pc we dont need to have seperate pc+ 4 and alu can perform that operation (pipelined needs to preform PC and arithemtic operation in same time)
- decoder now has funct3 funct7 output wires
- PC add signal is 1 when T (state tracker) is in fetch state, else in zero

additional notes
- combinational part should be simplified in similar method using instruction encoding as much as possible (not operation wire as it now stands).
- instruction decoder needs to send 0 signal for some wires depending on op code so it dosnt feeds confusing signals (noticed it might mess with funct7_i signal but also other signals) def need to check