### PR TITLE
Second iteration/main

### DIFF
--- a/alu.sv
+++ b/alu.sv
@@ -2,30 +2,35 @@
 
 module alu(
     input [31:0] a_i, b_i,
-    input [2:0] funct3_i,
-    input funct7_i,
     output [31:0] c_o,
-    //no pipeline input
-    input pc_add
+    output alu_flag,
+    input [3:0] alu_operation
     );
     
-    bit c_i;
-    
+    bit [31:0] _c_o;
+    bit _alu_flag;
+
     always_comb begin
-        if (pc_add) c_i = a_i + b_i; // in pipeline cpu pc needs seperate adder to preform fetch add pc, and execute instruction adds in same time
-        else begin
-            case (funct3_i)
-                3'b000: c_i = funct7_i ? (a_i + b_i) : (a_i - b_i); // add / sub
-                3'b001: c_i = a_i << b_i; // sll: rs1 is a_i, b_i is lower 5 bits of I-immidate 
-                3'b010: c_i = a_i < b_i; // slt
-                3'b011: c_i = a_i == b_i;  //sltu
-                3'b100: c_i = a_i ^ b_i; //xor
-                3'b101: c_i = funct7_i ? (a_i >> b_i) : (a_i >>> b_i); //srl / sra
-                3'b110: c_i = a_i | b_i; //or
-                3'b111: c_i = a_i & b_i; //and      
-            endcase
-        end             
+        //remove latch
+        _c_o <= 0; _alu_flag <= 0;
+        case (alu_operation)
+             4'b0000:  _c_o <= a_i + b_i; 
+             4'b0001:  _c_o <= a_i - b_i;// add / sub
+             4'b0010: _c_o <= a_i << b_i; //shiftleft
+             4'b0011:begin _c_o <= a_i < b_i; _alu_flag <= (a_i) < (b_i); end//sltu
+             4'b1011: begin _c_o <= $signed(a_i) < $signed(b_i); _alu_flag <= $signed(a_i) < $signed(b_i); end//sltu
+             4'b0100: _c_o <= a_i ^ b_i; //xor
+             4'b0101: _c_o <= a_i >> b_i;
+             4'b0110: _c_o <= $signed(a_i) >>> $signed(b_i);//srl / sra
+             4'b0111:begin _c_o <= a_i | b_i; _alu_flag <= a_i || b_i; end
+             4'b1000: begin _c_o <= a_i & b_i; _alu_flag <= a_i && b_i; end //and 
+             default:begin _c_o <= 0; _alu_flag <= 0; end
+          endcase   
+//        end             
     end
+    
+    assign c_o = _c_o;
+    assign alu_flag = _alu_flag;
     
     
 endmodule

--- a/cpu_top.sv
+++ b/cpu_top.sv
@@ -20,30 +20,23 @@ module cpu_top(
     
     );
     
-    
-    
     //state machine enum
-    typedef enum bit [2:0] {FETCH,DECODE,EXECUTE,MEMORY,WRITE_BACK} e_states;
-    typedef enum logic [31:0] {ADDI = 32'h1, SLTI = 32'h2, ANDI = 32'h4, ORI = 32'h8, XORI = 32'h10, LUI = 32'h20, AUIPC = 32'h40, SLLI = 32'h80, SRLI = 32'h100,
-                             SRAI = 32'h200, ADD = 32'h400, SUB = 32'h800,_XOR = 32'h1000, _OR = 32'h2000, _AND = 32'h4000, SLL = 32'h8000, SRL = 32'h10000,
-                             SLT = 32'h20000, LB = 32'h40000, LH = 32'h80000, LW = 32'h100000, SB = 32'h200000, SH = 32'h400000, SW = 32'h800000,
-                             JAL = 32'h1000000, JALR = 32'h2000000, BEQ = 32'h4000000 ,BEN = 32'h8000000, BLT = 32'h10000000, BGE = 32'h20000000, 
-	                         BLTU = 32'h40000000, BGEU = 32'h80000000} e_operations;
+    localparam FETCH = 3'b000;
+    localparam DECODE = 3'b001;
+    localparam EXECUTE = 3'b010;
+    localparam MEMORY = 3'b011;
+    localparam WRITE_BACK = 3'b100;
     
     //inst_decode wires
     wire[11:0] imm_I; 
     wire[6:0] imm_S, imm_B;
     wire[19:0] imm_U, imm_J;
     wire [4:0] rd, rs1, rs2;
-    wire jump_ops;
-    wire [3:0] funct3;
-    wire funct7;
     
+
+   
     
-    //signextended in multiples of two(first two LSB killed)
-    wire[31:0] sig_imm_I = { { 21{imm_I[11]} }, imm_I [11:1]};  
-    wire[31:0] sig_imm_B = {{25{1'b0}},imm_B[6:1]}; 
-    wire[31:0] sig_imm_J = { { 13{imm_J[19]} }, imm_J[19:1]};
+    wire [31:0] imm;
     
     localparam c_register_file_len = 5; // rv32i has 31 general-purpose registers x1-x31, which hold integer values
     //register file
@@ -51,334 +44,134 @@ module cpu_top(
     //program counter -> PC
     reg [31:0] PC = 32'd0;
     //instruction reg -> INST_REG
-    bit [31:0] INST_REG = 32'd0;
+    bit [31:0] INST_REG;
     
 	//TO DO: FENCE, FENCE.1, ECALL, EBREAK
+	
+	wire m2r_select;
 	
 	//setting regfile readports
     reg [31:0] qa;
 	reg [31:0] qb;
 	
     //registes for extra control  
-	logic [31:0] current_PC;
-	logic [31:0] c;
-	
+	bit [31:0] current_PC;
+	bit [31:0] c;
+	wire [31:0] memory_adress = c;
 	//load store wires
 	bit [31:0] _addr_data  = 32'b0;
-	bit [2:0]  _we_data = 4'b0000;
+	bit [2:0]  _we_data;
+	bit [31:0] data_reg; //register for storing data from memory/instructions
 	
 	//decode settings
 	bit [31:0] next_PC; //next_PC wire
-	bit [4:0] dest_rn = rd; //TODO: redundant 
-	logic [31:0] a; //adder port A TODO: rename to alu_B
-	logic [31:0] b;  //adder port B TODO: rename to alu_B
-	logic [31:0] ALU_out; //adder out port    
+	bit [31:0] a; //adder port A TODO: rename to alu_B
+	bit [31:0] b;  //adder port B TODO: rename to alu_B
+	bit [31:0] ALU_out; //adder out port    
 	
 	//to do: implement all mathematical operations vi alu
 	
-	
-	    
+	//control signals
+	wire[4:0] alu_operation;
+	wire [6:0] opcode;
+	 //pc_plus_4 for branch
 	  
-	 //assign enum to state tracker 
-     e_states T;
-     e_operations operation;
-    //combinational part - muxes (no registers or elements with clock)        
-    always_comb begin
-    //set defult states for no latches
-        next_PC <= ALU_out;
-        a <= PC;
-        b <= 31'd4;
-    //work part     
-	   case(T)
-	       FETCH:begin
-	           next_PC <= ALU_out;
-               a <= PC;
-               b <= 31'd4; 
-	       end
-	       DECODE:begin
-	           if(jump_ops)begin //in case of ALU and branch instructions
-                            case (operation)
-                                JAL:begin
-									if(dest_rn == 1'b0)begin //pseudo-instruction jump 1 cycle
-                                        a <= PC;
-                                        b <=  sig_imm_J;
-								    end	else begin //JAL part
-								        b <=  sig_imm_J;
-								        a <= current_PC; //TODO:check might be wrong
-								    end	
-                                end
-                                JALR:begin
-                                    //TODO: This is incomplete
-                                end
-                                AUIPC: begin 
-                                    //PC <= PC + {imm_U,{12'b0}}; //U-immediate in register rd (lowest 12 bits are zeroes) TODO: check!
-                                end
-                                LUI: begin
-                                    //c <= {imm_U,{12'b0}}; //U-immediate in register rd (lowest 12 bits are zeroes)  TODO: check!
-                                end
-                            endcase
-                        end else begin
-                                           //no combinational for this part
-                        end                      
-	       end
-	       EXECUTE: begin
-                case(operation) //change to opcode when inst decode is completed
-                            //immediate integer operations
-                            ADDI: begin
-                                a <= qa;
-                                b <= sig_imm_I;
-                            end
-                            SLTI: begin //writes 1 or 0 to reg[rd] depending on a<b //to do for marin
-                                a <= qa;
-                                b <= sig_imm_I;
-                                //ALU_out <= $signed(a) < $signed(b); //set c = qa < imm_I (logic operations need $signed function)  <<<< marin rjesi sta si tu htjeo
-                            end
-                            SRLI: begin
-                                a <= qa;
-                                b <= sig_imm_I;
-                            end
-                            SRAI: begin
-                                a <= qa;
-                                b <= sig_imm_I;
-                            end
-                            ANDI: begin
-                                a <= qa;
-                                b <= sig_imm_I;
-                            end
-                            ORI: begin
-                                a <= qa;
-                                b <= sig_imm_I;
-                            end
-                            XORI: begin
-                                a <= qa;
-                                b <= sig_imm_I;
-                            end //note, XORI rd, rs1, -1 performs a bitwise logical inversion of register rs1 (assembler pseudo-instruction NOT rd, rs) 
-                            LUI: begin
-                                a <= qa;
-                                b <= sig_imm_I;
-                            end
-                            AUIPC:begin 
-                                ALU_out <= PC; 
-                                b <= sig_imm_I;
-                            end
-                            //Register-Register operations
-                            ADD: begin
-                                a <= qa;
-                                b <= qb;
-                            end            
-                            SUB: begin
-                                a <= qa;
-                                b <= qb;
-                            end 
-                            _XOR: begin
-                                a <= qa;
-                                b <= qb;
-                            end 
-                            _OR: begin
-                                a <= qa;
-                                b <= qb;
-                            end 
-                            _AND: begin
-                                a <= qa;
-                                b <= qb;
-                            end 
-                            SRL: begin
-                                a <= qa;
-                                b <= qb;
-                            end 
-                            SLL: begin
-                                a <= qa;
-                                b <= qb;
-                            end 
-                            SLT: begin
-                                a <= qa;
-                                b <= qb;
-                            end 
-							//store instruction adress calculation 
-							(SB | SW | SH):begin
-							     a <= qa;
-							     b <= sig_imm_I; 
-							 end    
-							JALR: begin // TODO
-						    end 
-                        endcase	
-           end                     
-	       MEMORY: ;
-	   endcase
-	end  
-    //
-    //
-    //     SEQUENTIAL LOGIC PART
-    //
-    //    
-    always@(posedge aclk)begin 
-           if(aresetn)begin //work
-               case(T)
-                    FETCH : begin //INSTR fetch
-                        INST_REG <= data_in_inst;
-                        current_PC <= PC; //save current PC to register for control instructions 
-                        PC <= next_PC; //save next_PC to PC
-                        T <= DECODE;               
-                    end
-                    DECODE : begin //INSTR decode
-                        if(jump_ops)begin //in case of ALU and branch instructions
-                            case (operation)
-                                JAL:begin
-									if(dest_rn == 1'b0)begin //pseudo-instruction jump 1 cycle
-									   PC <= ALU_out;  //this is actually comb
-                                       T <= FETCH;                             
-								    end	else begin //JAL part
-								       PC <= ALU_out; //this is actually comb
-									   T <= EXECUTE;
-								    end	
-                                end
-                                JALR:begin
-                                    T <= MEMORY; // TODO: not done
-                                end
-                                AUIPC: begin 
-                                    T <= EXECUTE; // TODO: not done
-                                end
-                                LUI: begin
-                                    T <= WRITE_BACK; // TODO: not done
-                                end
-                            endcase
-                        end else begin // in case of ALU r to r 
-                            //setting regfile readports for ALU operations
-                            qa <= (rs1==0) ? 0 : REG_FILE[rs1];
-                        	qb <= (rs2==0) ? 0 : REG_FILE[rs2];
-                            T <= EXECUTE;                            
-                        end
-                           
-                    end
-                    EXECUTE: begin // INSTR exe                    
-                        case(operation) //change to opcode when inst decode is completed
-                            //immediate integer operations
-                            ADDI: begin
-                                c <= ALU_out; 
-                                T <= WRITE_BACK; //load and go to write
-                            end
-                            SLTI: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK; //load and go to write
-                            end
-                            SRLI: begin
-                                c <= ALU_out; 
-                                T <= WRITE_BACK;
-                            end
-                            SRAI: begin
-                                c <= ALU_out; 
-                                T <= WRITE_BACK;
-                            end
-                            ANDI: begin
-                                c <= ALU_out; 
-                                T <= WRITE_BACK;
-                            end
-                            ORI: begin
-                                c <= ALU_out; 
-                                T <= WRITE_BACK;
-                            end
-                            XORI: begin
-                                c <= ALU_out; 
-                                T <= WRITE_BACK;
-                            end 
-                            //note, XORI rd, rs1, -1 performs a bitwise logical inversion of register rs1 (assembler pseudo-instruction NOT rd, rs) 
-                            LUI:  begin
-                                c <= ALU_out; 
-                                T <= WRITE_BACK;
-                            end
-                            AUIPC:begin
-                                 c <= ALU_out; 
-                                 T <= WRITE_BACK; //load and go to write
-                            end
-                            //Register-Register operations
-                            ADD: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK; //load and go to write
-                            end            
-                            SUB: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK;
-                            end  
-                            _XOR: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK;
-                            end 
-                            _OR: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK;
-                            end 
-                            _AND: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK;
-                            end 
-                            SRL: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK;
-                            end 
-                            SLL: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK;
-                            end 
-                            SLT: begin
-                                c <= ALU_out;
-                                T <= WRITE_BACK;
-                            end 
-							//store instruction adress calculation 
-							(SB | SW | SH):begin 
-                                 c = ALU_out;
-							     T = MEMORY; //load and go to write
-							 end    
-							JALR: begin 
-//						         PC[0] <= 0; 
-						         T <= WRITE_BACK; //load and go to write
-						    end 
-                        endcase
-                    end
-                    MEMORY: begin //memory access state
-                    //TO DO: this needs to be redone but this is general scheme
-                //                        case (operation)
-//                            SB: _we_data <= 4'b0001;                                
-//                            SH: _we_data <= 4'b0011;
-//                            SW: _we_data <= 4'b1111;
-//                            //Load
-//                            LB: REG_FILE[dest_rn] <= {{24{data_in_data[31]}},data_in_data[31:24]};
-//                            LH: REG_FILE[dest_rn] <= {{16{data_in_data[31]}},data_in_data[31:16]};
-//                            LW: REG_FILE[dest_rn] <= data_in_data;
-//                         endcase
-                         T <= FETCH;        
-                    end
-                    WRITE_BACK: begin // write back state
-                        REG_FILE[dest_rn] <= c; //write back and go to first state
-                        T <= FETCH;
-                    end
-               endcase
-               
-           end
-           else begin       //reset
-                PC <= 32'd0;
-                T <= FETCH;
-           end
-    end
+	//assign enum to state tracker 
+    bit[2:0] T = 0;
+
+
+	wire [1:0] a_select;
+	wire [1:0] b_select;
+	wire [1:0] c_select;
+	wire PC_enable;
+	wire wb;
+	wire IR_enable;
+	wire [1:0] next_PC_select;
+	wire current_PC_enable;
+	
+	wire [31:0] PC_plus_4 = PC + 4;
+	
+	//mux for select
+	always_comb begin
+		case (a_select)
+			2'b00: a <= qa;
+			2'b01: a <= PC;
+			2'b10: a <= current_PC;
+			default: a <= 32'b0;
+		endcase
+		
+		case (b_select)
+			2'b00: b <= qb;
+			2'b01: b <= imm;
+			2'b10: b <= 3'd4; //not needed
+			default: b <= qb;		
+		endcase
+		  	
+		case (next_PC_select)
+		  2'b00: next_PC <= PC_plus_4;
+		  2'b01: next_PC <= ALU_out;
+		  2'b10: next_PC <= c; //not needed
+		  default: next_PC <= PC_plus_4;	
+		endcase
+	end
+	
+	always@(posedge aclk)begin
+	    qa <= (rs1==0) ? 0 : REG_FILE[rs1]; //loads into qa register (need to change name)
+        qb <= (rs2==0) ? 0 : REG_FILE[rs2]; //loads into qb register (need to change name)
+        data_reg <= data_in_data;
+        
+         
+		case (c_select)
+			2'b00: c <= REG_FILE[rs1];
+			2'b01: c <= ALU_out;
+			2'b10: c <= PC;
+			2'b11:	c <= imm;		
+		endcase
+		
+		case (PC_enable)
+			1'b0:; 
+			1'b1: PC <= next_PC;
+		endcase
+		
+		case (wb)
+			1'b0: ;
+			1'b1: begin 
+			 REG_FILE[rd] <= m2r_select ? data_reg : c;
+			 end
+		endcase
+		
+		case (IR_enable)
+			1'b0: ;
+			1'b1: INST_REG <= data_in_inst;
+		endcase
+		
+		case(current_PC_enable)
+		  1'b0: ;
+		  1'b1: current_PC <= PC;
+		endcase
+		
+	end
     
     //net assigments
+    assign data_out_data = REG_FILE[qb]; // for store
+    assign addr_data = memory_adress; //c is memory adress
     assign addr_inst = PC[31:3]; //use word adress to read memory
 	assign REG_FILE[0] = 32'h00; //register x0 is hardwired to the constant
 	assign we_data = _we_data;
-	assign addr_data = _addr_data;
-	wire pc_add = (T == FETCH) ? 1'b1 : 1'b0;
-	
+	//assign addr_data = _addr_data;
+	wire alu_flag;
 	//instantiations
-	 inst_decode my_inst( .data_in_inst,
-     .operation,
-     .imm_I, 
-     .imm_S , .imm_B ,
-     .imm_U , .imm_J,
+	 inst_decode my_inst( .INST_REG,
      .rd, .rs1, .rs2,
-     .jump_ops,
-     .funct3, .funct7
+     .imm, 
+     .alu_operation,
+     .opcode,
+     .aclk,
+     .a_select,.b_select,.c_select,.next_PC_select, .wb, .alu_flag, .IR_enable, .PC_enable, .current_PC_enable, .m2r_select, ._we_data
      );
     
-    alu alu_inst_0(.a_i(a), .b_i(b), .c_o(ALU_out), .funct3_i(funct3), .funct7_i(funct7), .pc_add(pc_add));
+    alu alu_inst_0(.a_i(a), .b_i(b), .c_o(ALU_out), .alu_operation(alu_operation), .alu_flag(alu_flag));
+
 
 	
 endmodule

--- a/decoder.sv
+++ b/decoder.sv
@@ -1,124 +1,405 @@
 `timescale 1ns / 1ps
 
 module inst_decode(
-    input[31:0]  data_in_inst,
-    output[31:0] operation,
-    output[11:0] imm_I, 
-    output[6:0] imm_S, imm_B,
-    output[19:0] imm_U, imm_J,
+    input[31:0]  INST_REG,
+    input aclk,
+    input alu_flag,
     output [4:0] rd, rs1, rs2,
-    output jump_ops,
-    output [3:0] funct3,
-    output funct7
-    );
-    typedef enum bit [31:0] {ADDI = 32'h1, SLTI = 32'h2, ANDI = 32'h4, ORI = 32'h8, XORI = 32'h10, LUI = 32'h20, AUIPC = 32'h40, SLLI = 32'h80, SRLI = 32'h100,
-                             SRAI = 32'h200, ADD = 32'h400, SUB = 32'h800,_XOR = 32'h1000, _OR = 32'h2000, _AND = 32'h4000, SLL = 32'h8000, SRL = 32'h10000,
-                             SLT = 32'h20000, LB = 32'h40000, LH = 32'h80000, LW = 32'h100000, SB = 32'h200000, SH = 32'h400000, SW = 32'h800000,
-                             JAL = 32'h1000000, JALR = 32'h2000000, BEQ = 32'h4000000 ,BEN = 32'h8000000, BLT = 32'h10000000, BGE = 32'h20000000, 
-	                         BLTU = 32'h40000000, BGEU = 32'h80000000} e_operations;
+    output [31:0] imm,
+    output alu_operation,
+    output[6:0] opcode,
+    output [1:0] a_select,
+    output [1:0] b_select,
+    output [1:0] c_select, //regfile select (it can be interpeted as ALU_out select need to refactor)
+    output [1:0] next_PC_select,
+    output PC_enable, //regfile select
+    output IR_enable,
+    output wb,
+    output current_PC_enable,
+    output m2r_select, //select adress from rd(reg destination, 0) or c(memory destination, 1)
+    output [3:0] _we_data
     
+    );
+    localparam FETCH = 3'b000;
+    localparam DECODE = 3'b001;
+    localparam EXECUTE = 3'b010;
+    localparam MEMORY = 3'b011;
+    localparam WRITE_BACK = 3'b100;
+    
+    //typedef enum bit [2:0] {FETCH,DECODE,EXECUTE,MEMORY,WRITE_BACK} e_states;
+//    typedef enum bit [31:0] {ADDI = 32'h1, SLTI = 32'h2, ANDI = 32'h4, ORI = 32'h8, XORI = 32'h10, LUI = 32'h20, AUIPC = 32'h40, SLLI = 32'h80, SRLI = 32'h100,
+//                             SRAI = 32'h200, ADD = 32'h400, SUB = 32'h800,_XOR = 32'h1000, _OR = 32'h2000, _AND = 32'h4000, SLL = 32'h8000, SRL = 32'h10000,
+//                             SLT = 32'h20000, LB = 32'h40000, LH = 32'h80000, LW = 32'h100000, SB = 32'h200000, SH = 32'h400000, SW = 32'h800000,
+//                             JAL = 32'h1000000, JALR = 32'h2000000, BEQ = 32'h4000000 ,BEN = 32'h8000000, BLT = 32'h10000000, BGE = 32'h20000000, 
+//	                         BLTU = 32'h40000000, BGEU = 32'h80000000} e_operations;
     
     //R-type instruction parts decoder
-    wire [6:0] opcode = data_in_inst [6:0];
-    wire [4:0] _rd = data_in_inst [11:7];
-    wire [2:0] _funct3 = data_in_inst [14:12];
-    wire [4:0] _rs1 = data_in_inst [19:15];
-    wire [4:0] _rs2 = data_in_inst [24:20];
-    wire [6:0] _funct7 = data_in_inst [31:25];
-    //immediate decoder
-    wire [11:0] _imm_I = data_in_inst[31:20];
-    wire [6:0] _imm_S = {data_in_inst[31:25], data_in_inst[11:7]};
-    wire [6:0] _imm_B = {data_in_inst[31], data_in_inst[7], data_in_inst[30:25], data_in_inst[11:8]};
-    wire [19:0] _imm_U = data_in_inst [31:12];
-    wire [19:0] _imm_J = {data_in_inst [31], data_in_inst[19:12], data_in_inst[20], data_in_inst[30:25], data_in_inst[24:21]};
- 
- //instruction format decode
-    //Integer Register-Immediate Instructions (I-type operations)
-    wire imm_alu_op = (opcode == 7'b0010011); 
-    //Integer Register-Register Operations
-    wire reg_alu_op = (opcode == 7'b0110011); 
-    //NOP 
-    //?? 
-	
-    //Conditional branches
-    wire branch_op = (opcode == 7'b1100011);
-    //Load and store instructions
-    wire load_op = (opcode == 7'b0000011);
-    wire store_op = (opcode == 7'b0100011);
+    wire [6:0] _opcode = INST_REG [6:0];
+    wire [4:0] _rd = INST_REG [11:7];
+    wire [2:0] _funct3 = INST_REG [14:12];
+    wire [4:0] _rs1 = INST_REG [19:15];
+    wire [4:0] _rs2 = INST_REG [24:20];
+    wire [6:0] _funct7 = INST_REG [31:25];
     
-//instruction decode    
-    //immediate    
-    wire _addi =  imm_alu_op & (funct3 == 3'h0); // add immediate
-    wire _slti = imm_alu_op & (funct3 == 3'h2); // set less then immediate
-    wire _andi = imm_alu_op & (funct3 == 3'h7); // and immediate
-    wire _ori = imm_alu_op & (funct3 == 3'h6); // or immediate
-    wire _xori = imm_alu_op & (funct3 == 3'h4); // xor immediate
-    wire _lui = (opcode == 7'b0110111); // load upper immediate
-    wire _auipc = (opcode == 7'b0010111); // // add upper immediate to PC
-    wire _slli = imm_alu_op & (funct3 == 3'h1) & (imm_I[11:5] == 7'h00); //shift left logical immediate
-    wire _srli = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h00); //shift right logical immediate
-    wire _srai = imm_alu_op & (funct3 == 3'h5) & (imm_I[11:5] == 7'h20); //shift right arithmetic immediate
-    //register to register alu ops
-    wire _add = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h00); //add rs1 and rs2
-    wire _sub = reg_alu_op & (funct3 == 3'h0) & (funct7 == 7'h20); //sub rs1 and rs2
-    wire __xor = reg_alu_op & (funct3 == 3'h4) & (funct7 == 7'h00); //xor rs1 and rs2
-    wire __or = reg_alu_op & (funct3 == 3'h6) & (funct7 == 7'h00); //or rs1 and rs2
-    wire __and = reg_alu_op & (funct3 == 3'h7) & (funct7 == 7'h00); //and rs1 and rs2
-    wire _sll = reg_alu_op & (funct3 == 3'h1) & (funct7 == 7'h00); //shift left logical rs1 and rs2
-    wire _srl = reg_alu_op & (funct3 == 3'h5) & (funct7 == 7'h00); //shift right logical rs1 and rs2
-    wire _slt = reg_alu_op & (funct3 == 3'h2) & (funct7 == 7'h00); //set les then if rs1 is less then imm
-    //load
-    wire _lb = load_op & (funct3 == 3'h0); //load byte
-    wire _lh = load_op & (funct3 == 3'h1); //load half word
-    wire _lw = load_op & (funct3 == 3'h2); //load word
-    //store
-    wire _sb = store_op & (funct3 == 3'h0); //store byte
-    wire _sh = store_op & (funct3 == 3'h1); //store half word
-    wire _sw = store_op & (funct3 == 3'h2); //store word
-    //control
-	//Unconditional jumps
-    wire _jal = (opcode == 7'b1101111);
-    wire _jalr = (opcode == 7'b1100111) & (funct3 == 3'h7);
-    //branch
-	wire _beq = branch_op & (funct3 == 3'h0); //branch if equale
-	wire _ben = branch_op & (funct3 == 3'h1); //branch if not equale
-	wire _blt = branch_op & (funct3 == 3'h4); //branch if less then zero
-	wire _bge = branch_op & (funct3 == 3'h5); //branch greater or equale
-	wire _bltu = branch_op & (funct3 == 3'h6); //brench if less then *unsigned
-	wire _bgeu = branch_op & (funct3 == 3'h7); //branch if greater or equale then *unsigned
-	
-
-	wire _jump_ops = (_jal | _jalr); //select j immedieta
-	
-
-	   
-	
-
-	
-	//operations into vector 
-	bit [31:0] _operation = {_addi, _slti, _andi, _ori, _xori, _lui, _auipc, _slli, _srli, _srai, _add, _sub,
-	                        __xor, __or, __and, _sll, _srl, _slt, _lb, _lh, _lw, _sb, _sh, _sw, _jal, _jalr, 
-	                        _beq ,_ben, _blt, _bge, _bltu, _bgeu};
-	                        
-    //net assignments
-    assign operation = _operation;
-
-    assign imm_I = _imm_I; 
-    assign imm_S = _imm_S;
-    assign imm_B = _imm_B;
-    assign imm_U = _imm_U;
-    assign imm_J = _imm_J;
+    bit [2:0] next_state;
+// instruction format decode
+//    Integer Register-Immediate Instructions (I-type operations)
+//    wire imm_alu_op = (opcode == 7'b0010011); 
+//    //Integer Register-Register Operations
+//    wire reg_alu_op = (opcode == 7'b0110011); 
+//    //lui aui
+//    wire lui = (opcode == 7'b0110111);
+//    wire aui = (opcode == 7'b0010011);
+//    //interupts 
+//	wire csr_op = (opcode == 7'b1110011);
+//    //Conditional branches
+//    wire branch_op = (opcode == 7'b1100011);
+//    //Load and store instructions
+//    wire load_op = (opcode == 7'b0000011);
+//    wire store_op = (opcode == 7'b0100011);
+//    wire jalr_op = (opcode == 7'b1100111);
+//    wire _jal_op = (opcode == 7'b1101111); //needed
+//    wire srrli = (opcode == 7'b0010011);
+    bit[2:0] T = 0;
+    bit [1:0] _a_select; //select a_alu_input (reg a, PC, current_PC) 
+    bit [1:0] _b_select; //select b_alu_input (reg b, imm)
+    bit [1:0] _c_select; //select for c reg file (ALU_out, imm, REGFILE[rs1], PC)
+    bit [1:0] _next_PC_select; //select next PC output (PC+4, ALU_out, c, PC)
+    bit _PC_enable; //enable write to pc
+    bit _IR_enable; //enable write to instruction register
+    bit _wb; //enable write to regfile
+    bit _current_PC_enable; //current pc enable
+    bit areset;
+    bit [3:0] _alu_operation;
+    bit _m2r_select; //memory to register
+    bit we_data;
+    
+    
+   
+    //immideate multiplexer
+    bit [31:0] _imm;
+    
+    //combinational for choosing immidiate and alu_ops
+    always_comb begin
+        //imm select
+        case(_opcode)
+            7'b0100011: _imm <= {{20{INST_REG[31]}},INST_REG[31:25], INST_REG[11:7]}; //S type store
+            7'b1100011: _imm <= {{20{INST_REG[31]}},INST_REG[31:25], INST_REG[11:8], 1'b0}; //B type branch
+            7'b0010011, 7'b1100111, 7'b0000011: _imm <= {{20{INST_REG[31]}},{INST_REG[31:20]}}; //I type (imm_alu_op or load or jalr)
+            7'b0110111 , 7'b0010011: _imm <=  {{12{INST_REG[31]}},{INST_REG[31:12]}}; //U type (LUI or AUI)
+            7'b1101111: _imm <= {{12{INST_REG[31]}}, INST_REG[19:12], INST_REG[20], INST_REG[30:25], INST_REG[24:21], 1'b0}; // j type jal
+            7'b1110011, 7'b0110011: _imm <= 7'b0; // r type (csr, reg_alu_op)
+            default: _imm <= 7'b0;           
+        endcase
+        
+        //ALU operation select (without fetch)  
+        case(_opcode) //prebacit u alu
+            7'b1100011:begin //branch
+                 case (_funct3)
+                     3'b000: _alu_operation <= 4'b1000; // equale
+                     3'b001: _alu_operation <= 4'b1001; //not equale
+                     3'b100: _alu_operation <= 4'b0011; //less
+                     3'b101: _alu_operation <= 4'b1010; //greater
+                     3'b110: _alu_operation <= 4'b1011; //less then unsigned
+                     3'b111: _alu_operation <= 4'b1100; //greater then unsigned
+                     default: _alu_operation <= 4'b0000;       
+                 endcase
+            end   
+            7'b1101111: _alu_operation <= 4'b0000; // jal (this is diffrent in pipelined)
+            7'b0110011, 7'b0010011: begin // r type
+                 case (_funct3)
+                     3'b000: _alu_operation <= _funct7[5] ? 4'b0000 : 4'b0001; // add / sub
+                     3'b001: _alu_operation <= 4'b0010; //shiftleft
+                     3'b010: _alu_operation <= 4'b0011; // lessthen
+                     3'b011: _alu_operation <= 4'b1011;  //sltu
+                     3'b100: _alu_operation <= 4'b0100; //xor
+                     3'b101: _alu_operation <= funct7 ? 4'b0101 : 4'b0110; //srl / sra
+                     3'b110: _alu_operation <=  4'b0111;//or
+                     3'b111: _alu_operation <=  4'b1000; //and 
+                     default: _alu_operation <= 4'b0000;        
+                 endcase
+            end
+            default: _alu_operation <= 4'b0000; 
+        endcase
+        
+             //defult cases for operations 
+        _a_select <= 2'b10; //PC
+        _b_select <= 2'b10; //constant 4
+        _PC_enable <= 1'b1; // PC <= ALU_out 
+        _next_PC_select <= 2'b01; //redirect alu_out to pc
+        _IR_enable <= 1'b0;
+        _c_select <= 2'b10; // save jump adress to registar c   
+        _wb <= 1'b0;
+        _current_PC_enable <= 1'b1; 
+        _m2r_select <= 1'b0;
+        we_data <= 4'b0000;      
+        
+        //
+        case(T)
+            FETCH:begin
+                _IR_enable <= 1'b1;
+                _PC_enable <= 1'b1; //select PC <= next_PC regtype
+                _next_PC_select <= 2'b00; // pc <= pc_plus_4
+                _current_PC_enable <= 1'b1;
+                _a_select <= 2'b00; //PC
+                _b_select <= 2'b01; //imm
+                _c_select <= 2'b10; // save jump adress to registar c
+                _m2r_select <= 1'b0;
+                we_data <= 4'b0000;  
+            end
+            DECODE:begin
+                case(_opcode)
+                    7'b0010011:begin  //imm
+                        _a_select <= 2'b01;
+                        _PC_enable <= 1'b0; //no nextPC select
+                        _c_select <= 2'b00; //REG_FILE[rs] //reg file  for pseudo mv ,goes to writeback if rs = 0 TODO
+                        _next_PC_select <= 2'b00; // pc <= pc_plus_4
+                        //qa <= regfile[rs1] and qa <= regfile[rs2] is done regardlessly
+                    end
+                    7'b0110011:begin //reg
+                        _a_select <= 2'b01;
+                        _PC_enable <= 1'b0; //no nextPC select
+                        _next_PC_select <= 2'b00; // pc <= pc_plus_4
+                        //qa <= regfile[rs1] and qa <= regfile[rs2] is done regardlessly
+                    end
+                    7'b0110111: begin //lui
+                        _PC_enable <= 1'b0; //no nextPC select
+                        _c_select <= 2'b11; //immmediate regtype
+                        _next_PC_select <= 2'b00; // pc <= pc_plus_4
+                    end
+                    7'b0010011:begin //aui
+                        _a_select <= 2'b10; //current_PC
+                        _b_select <= 2'b01; //imm
+                        _next_PC_select <= 2'b01; //redirect alu_out to pc
+                        _PC_enable <= 1'b1; // write enable to pc (PC <= ALU_out)       
+                    end
+                    7'b1110011: ; //csr
+                    7'b1100011:begin //branch
+                        _a_select <= 2'b00; //PC
+                        _b_select <= 2'b01; //imm
+                        _c_select <= 2'b10; // save jump adress to registar c
+                        _PC_enable = 1'b0;
+                        _next_PC_select <= 2'b00; // pc <= pc_plus_4       
+                    end
+                    7'b0000011: ; //load //qa <= regfile[rs1] and qa <= regfile[rs2] is done regardlessly
+                    7'b0100011: ; //store //qa <= regfile[rs1] and qa <= regfile[rs2] is done regardlessly
+                    //jalr
+                    7'b1100111: ;  //qa <= regfile[rs1] and qa <= regfile[rs2] is done regardlessly //jalr
+                    7'b1101111: begin //jal
+                       _a_select <= 2'b00; //PC
+                       _b_select <= 2'b01; //imm
+                       _c_select <= 2'b10; // save jump adress to registar c
+                       _next_PC_select <= 2'b01; //redirect alu_out to pc
+                       _PC_enable <= 1'b1; 
+                    end 
+                    7'b0010011: ; //sssrli // b = rs2 TODO
+                    default:begin
+                        _a_select <= 2'b00; //PC
+                        _b_select <= 2'b10; //constant 4
+                        _PC_enable <= 1'b1; // PC <= ALU_out 
+                        _next_PC_select <= 2'b00; //redirect alu_out to pc
+                        _c_select <= 2'b10; // save jump adress to registar c
+                        _wb <= 0;
+                        _current_PC_enable <= 1'b0;
+                        _IR_enable <= 1'b0;
+                        _m2r_select <= 1'b0;
+                        we_data <= 4'b0000;  
+                    end    
+                 endcase
+            end         
+            EXECUTE:begin    
+                case(_opcode)
+                    7'b0010011:begin  //imm
+                        _a_select <= 2'b01; //qa
+                        _b_select <= 2'b01; //imm
+                        _c_select <= 2'b01; // write to c
+                        _PC_enable <= 1'b0;
+                     end
+                    7'b0110011:begin //reg
+                        _a_select <= 2'b01; //qa
+                        _b_select <= 2'b00; //qb
+                        _c_select <= 2'b01; //write to c
+                        _PC_enable <= 1'b0;
+                    end
+//                    7'b1110011: ; //csr
+                    7'b1100011:begin //branch
+                        _a_select <= 2'b01; //qa
+                        _b_select <= 2'b00; //qb
+                        _next_PC_select <= 2'b10; //redirect c to pc
+                        _PC_enable <= alu_flag ? 1'b0 : 1'b1;       
+                    end
+                    7'b0000011:begin //load
+                        _a_select <= 2'b01; //qa
+                        _b_select <= 2'b01; //imm                       
+                    end
+                    7'b0100011:begin  //store
+                        _a_select <= 2'b01; //qa
+                        _b_select <= 2'b01; //imm  
+                    end
+                    7'b1100111: begin  //jalr
+                       _a_select = 2'b01; //qa
+                       _b_select = 2'b01; //imm
+                       _c_select = 2'b01; //write ALU_out to c (set to zero if rd = 0 ???)
+                       _next_PC_select <= 2'b01; //redirect alu_out to pc
+                       _PC_enable <= 1'b1; // enable write to pc
+                    end    
+                    7'b0010011: ; //sssrli // b = rs2 TODO
+                    default:begin
+                        _a_select <= 2'b01; //qa
+                        _b_select <= 2'b10; //constant 4
+                        _PC_enable <= 1'b0; // PC <= ALU_out 
+                        _next_PC_select <= 2'b00; //redirect alu_out to pc
+                        _c_select <= 2'b10; // save jump adress to registar c
+                        _wb <= 0;
+                        _current_PC_enable <= 1'b0;
+                        _IR_enable <= 1'b0;
+                        we_data <= 4'b0000; 
+                    end    
+                endcase 
+             end
+             MEMORY:begin
+                  
+               case(_opcode)
+                    7'b0000011: _m2r_select <= 1'b0; //load 
+                    7'b0100011:begin //store
+                        we_data <= 4'b1111;
+						_m2r_select <= 1'b0;		
+                    end    
+                    default:begin
+                        _a_select <= 2'b00; //PC
+                        _b_select <= 2'b10; //constant 4
+                        _PC_enable <= 1'b0; // PC not enabled
+                        _next_PC_select <= 2'b00; //redirect alu_out to pc
+                        _c_select <= 2'b10; // save jump adress to registar c
+                        _wb <= 0;
+                        _current_PC_enable <= 1'b0;
+                        _IR_enable <= 1'b0;
+                        we_data <= 4'b0000; 
+                    end    
+               endcase 
+             end
+             WRITE_BACK:begin
+                 we_data <= 4'b0000;   
+                 _wb <= 1'b1;
+                 _PC_enable <= 1'b0;
+                 _current_PC_enable <= 1'b0; 
+                 if (_opcode == 7'b0000011) _m2r_select <= 1'b0;  //load TODO
+                 else _m2r_select <= 1'b1;   
+             end              
+        endcase
+    
+    
+    
+    
+        
+    next_state <= FETCH; 
+   ///state machine
+        case(T)
+                FETCH:begin
+                    next_state <= DECODE;
+                end
+                DECODE:begin
+                    case(_opcode)
+                        7'b0010011:begin  //imm
+                           next_state <= EXECUTE;
+                        end
+                        7'b0110011:begin //reg
+                            next_state <= EXECUTE;
+                        end
+                        7'b0110111: begin //lui
+                            next_state <= WRITE_BACK;
+                        end
+                        7'b0010011:begin //aui
+                           next_state <= FETCH;     
+                        end
+                        7'b1110011: ; //csr
+                        7'b1100011:begin //branch
+                            next_state <= EXECUTE;      
+                        end
+                        7'b0000011: next_state <= EXECUTE; //load
+                        7'b0100011: next_state <= EXECUTE; //store
+                        7'b1100111: next_state <= EXECUTE; //jalr
+                        7'b1101111: begin //jal
+                           next_state <= (_rd == 0) ?  WRITE_BACK : FETCH; //pseudo  jump
+                        end 
+                        7'b0010011: next_state <= EXECUTE ; //sssrli // b = rs2 TODO
+                        default:begin
+                            next_state <= EXECUTE;
+                        end    
+                     endcase
+                end         
+                EXECUTE:begin    
+                    case(_opcode)
+                        7'b0010011:begin  //imm
+                            next_state <= WRITE_BACK;
+                         end
+                        7'b0110011:begin //reg
+                            next_state <= WRITE_BACK;
+                        end
+                        7'b1100011:begin //branch
+                            next_state <= FETCH;       
+                        end
+                        7'b0000011: next_state <= WRITE_BACK; //load
+                        7'b0100011: next_state <= MEMORY; //store
+                        7'b1100111: begin  //jalr
+                           next_state <= (_rd == 0) ? WRITE_BACK : FETCH;
+                        end    
+                        default:begin
+                            next_state <= WRITE_BACK;
+                        end   
+                    endcase 
+                 end
+                 MEMORY:begin    
+                    case(_opcode)
+                        7'b0000011: next_state <= WRITE_BACK; //load 
+                        7'b0100011: next_state <= FETCH; //store
+                        default:begin
+                            next_state <= FETCH;
+                        end   
+                    endcase 
+                 end
+                 WRITE_BACK:begin    
+                   next_state <= FETCH;
+                 end                  
+            endcase
+         
+     end
+     
+    always@(posedge aclk)begin
+        T <= next_state;
+    end                    
     
     assign rd = _rd;
     assign rs1 = _rs1;
     assign rs2 = _rs2;
 
-    assign jump_ops = _jump_ops;
+//    assign jump_ops = _jump_ops;
     
     assign funct3 = _funct3;
     assign funct7 = _funct7[5];
      
+    assign imm = _imm;
     
-                            
+//    assign jal_op = _jal_op;
+    
+    assign alu_operation = _alu_operation;
+    
+//    assign _T = T;   
+    
+//    assign a_select = _a_select;                     
+    
+    assign opcode = _opcode;
+    
+    assign a_select = _a_select;
+    assign b_select = _b_select;
+    assign c_select = _c_select; //regfile select (it can be interpeted as ALU_out select need to refactor)
+    assign PC_enable = _PC_enable; //regfile select
+    assign wb = _wb;
+    assign next_PC_select = _next_PC_select;
+    assign IR_enable = _IR_enable;
+    assign current_PC_enable = _current_PC_enable;
+    assign m2r_select = _m2r_select;
+    assign _we_data = we_data;
+    
     
 endmodule


### PR DESCRIPTION
### inst_decode
control signals (states, specific instruction parts) are now all part of inst_decode. According to this control signal - register and muxes in cpu top are controlled. This control signals are 


1. output [1:0] a_select - select a_alu_input (reg a(1), PC(0), current_PC(2)) 
2. output [1:0] b_select - select b_alu_input (reg b(0), imm(1))
3.  output [1:0] c_select - select for c reg file (ALU_out(0), imm(1), REGFILE[rs1](2), PC(3))
4.  output [1:0] next_PC_select - select next PC output (PC+4(0), ALU_ou(1)t, c(2), PC(3))
5.  output PC_enable - enable write to pc
6. output IR_enable - enable write to instruction register
7.  output wb - enable write to regfile
8. output current_PC_enable - current pc enable (not implanted)
9.  output m2r_select - select memory to register(1) or c to reg (0)
10.  output [3:0] _we_data - enables writing to data file

These control signals are generated according to instruction opcode and statemachine that is internal to inst_decode module.  Next state data is produced according to current state and opcode.

All instructions are implanted except csr, fence, half/byte store/load (only whole word is implanted), and operations with greaterthen (a and b should switch for its implementation). 

### cpu_top

- cpu_top is now collection of muxes and registers that are controlled by inst_decode.
- bram interface mostly connected 
- see inst_decode for instructions and what selector data does
- branch instruction should be incremented after jump so i ran out of ideas on how to implant PC + 4 trough alu, anyways if we were upgrading it to pipelined cpu it should have seperate adder. It seems that riscv was designed in mind that its implemantation is pipelined.

### alu
- removed pc_add
- added flag so we can do branch instructions in less cycles (this goes to inst_decode)

### testing
Soma basic testbenches were performed, but need working memory module for further testing.

###TODO
- some logic elements (variables) should be renamed. a or b should be - alu_a and alu_b or alu_a_in and alu_b_in. qa and qb should a and b etc. 
- since i cant use block ram generator on systemverilog lots of things werent tested, further testbench is needed after solving this problem
- case statements that are too long and complicated should be replaced with if else, now as it stands theres too much room for mistake (wrong default or no default etc.), all this errors should be checked and fixed during tb (and double checked by hand before tb). 
- write more detailed documentation for this change, that also includes excel tables, diagrams (in  progress)
- some design tips as Filip suggested ie hot one pick for state machine and other muxes are in plan
- I done lot of work with this commit, but since we need it for next stage of work this commit was little bit rushed considering all complicated case statements that were added